### PR TITLE
Migrert til distroless

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,5 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
-COPY build/libs/*all.jar app.jar
+FROM gcr.io/distroless/java21
+COPY build/libs/*all.jar ./app.jar
 ENV JAVA_OPTS="-Dlogback.configurationFile=logback-remote.xml"
+USER nonroot
+CMD [ "app.jar" ]

--- a/backend/naiserator-dev.yaml
+++ b/backend/naiserator-dev.yaml
@@ -38,8 +38,6 @@ spec:
     paths:
       - kvPath: oracle/data/dev/creds/emottak_q1-srvemottaknais
         mountPath: /secrets/emottak-monitor/credentials
-      - kvPath: /kv/preprod/fss/emottak-monitor/team-emottak
-        mountPath: /secrets/default
   observability:
     logging:
       destinations:

--- a/backend/naiserator-prod.yaml
+++ b/backend/naiserator-prod.yaml
@@ -38,8 +38,6 @@ spec:
     paths:
       - kvPath: oracle/data/prod/creds/emottak-srvemottaknais
         mountPath: /secrets/emottak-monitor/credentials
-      - kvPath: /kv/prod/fss/emottak-monitor/default
-        mountPath: /secrets/default
   observability:
     logging:
       destinations:


### PR DESCRIPTION
Migrert `backend` i `emottak-monitor` til distroless. Har ikke rørt `frontend` ettersom denne ikke benytter et `navikt`-image.

Har også tatt vekk Vault-secret som ikke ser ut til å være i bruk.