### PR TITLE
Korrigerer lenke i MessagesTableEbms.tsx

### DIFF
--- a/frontend/src/pages/MessagesTableEbms.tsx
+++ b/frontend/src/pages/MessagesTableEbms.tsx
@@ -168,7 +168,7 @@ const MessagesTable = () => {
                       <React.Fragment key={readableId}>
                         <Link
                             key={readableId}
-                            to={`/logg/${readableId}`}
+                            to={`/loggebms/${readableId}`}
                             state={{ backgroundLocation: location }}
                         >{readableId}</Link>
                         {idx < arr.length - 1 && ', '}


### PR DESCRIPTION
Korrigerer lenke for `MessagesTableEbms.tsx` (URL-sti `/meldingerebms`) til Mottak-id logg for EBMS (nye emottak - URL `/loggebms/<mottak-id>`).

Oppgave: https://github.com/navikt/team-emottak-docs/issues/239