### PR TITLE
256 Bug: DatePiker gikk ut av drift 

### DIFF
--- a/frontend/src/components/Filter.tsx
+++ b/frontend/src/components/Filter.tsx
@@ -15,9 +15,7 @@ type FilterProps<T, K extends keyof T> = {
   onFromTimeChange: (value: string) => void;
   onToDateChange: (value: string) => void;
   onToTimeChange: (value: string) => void;
-  onFromDateBlur?: () => void;
   onFromTimeBlur?: () => void;
-  onToDateBlur?: () => void;
   onToTimeBlur?: () => void;
   onFilterChange: (key: K, value: T[K]) => void;
   filterKeys?: K[];
@@ -34,9 +32,7 @@ const Filter = <T, K extends keyof T>({
   onToDateChange,
   onToTimeChange,
   onFilterChange,
-  onFromDateBlur,
   onFromTimeBlur,
-  onToDateBlur,
   onToTimeBlur,
   filterKeys = ["role", "service", "action", "status"] as K[],
 }: FilterProps<T, K>) => {
@@ -68,7 +64,6 @@ const Filter = <T, K extends keyof T>({
             inputId="datepicker-input-fom"
             value={fromDate}
             onChange={onFromDateChange}
-            onBlur={onFromDateBlur ?? (() => {})}
             inputProps={{
               name: "dateInput",
               "aria-invalid":
@@ -157,7 +152,6 @@ const Filter = <T, K extends keyof T>({
             inputId="datepicker-input-tom"
             value={toDate}
             onChange={onToDateChange}
-            onBlur={onToDateBlur ?? (() => {})}
             inputProps={{
               name: "dateInput",
               "aria-invalid":

--- a/frontend/src/pages/EventsTable.tsx
+++ b/frontend/src/pages/EventsTable.tsx
@@ -29,8 +29,6 @@ type EventInfo = {
 const EventsTable = () => {
   const location = useLocation();
 
-  const [fromDateDraft, setFromDateDraft] = useState(initialDate(""));
-  const [toDateDraft, setToDateDraft] = useState(initialDate(""));
   const [fromTimeDraft, setFromTimeDraft] = useState(initialTime(""));
   const [toTimeDraft, setToTimeDraft] = useState(initialTime(""));
 
@@ -49,8 +47,6 @@ const EventsTable = () => {
     `/v1/henthendelser?fromDate=${debouncedFromDate}%20${debouncedFromTime}&toDate=${debouncedToDate}%20${debouncedToTime}`
   );
 
-  const commitFromDate   = () => setFromDate(fromDateDraft);
-  const commitToDate     = () => setToDate(toDateDraft);
   const commitFromTime   = () => setFromTime(fromTimeDraft);
   const commitToTime     = () => setToTime(toTimeDraft);
 
@@ -110,13 +106,11 @@ const EventsTable = () => {
         fromTime={debouncedFromTime}
         toDate={debouncedToDate}
         toTime={debouncedToTime}
-        onFromDateChange={setFromDateDraft}
+        onFromDateChange={setFromDate}
         onFromTimeChange={setFromTimeDraft}
-        onToDateChange={setToDateDraft}
+        onToDateChange={setToDate}
         onToTimeChange={setToTimeDraft}
-        onFromDateBlur={commitFromDate}
         onFromTimeBlur={commitFromTime}
-        onToDateBlur={commitToDate}
         onToTimeBlur={commitToTime}
         messages={events ?? []}
         onFilterChange={handleFilterChange}

--- a/frontend/src/pages/EventsTableEbms.tsx
+++ b/frontend/src/pages/EventsTableEbms.tsx
@@ -29,8 +29,6 @@ type EventInfo = {
 const EventsTable = () => {
   const location = useLocation();
 
-  const [fromDateDraft, setFromDateDraft] = useState(initialDate(""));
-  const [toDateDraft, setToDateDraft] = useState(initialDate(""));
   const [fromTimeDraft, setFromTimeDraft] = useState(initialTime(""));
   const [toTimeDraft, setToTimeDraft] = useState(initialTime(""));
 
@@ -49,8 +47,6 @@ const EventsTable = () => {
     `/v1/henthendelserebms?fromDate=${debouncedFromDate}%20${debouncedFromTime}&toDate=${debouncedToDate}%20${debouncedToTime}`
   );
 
-  const commitFromDate   = () => setFromDate(fromDateDraft);
-  const commitToDate     = () => setToDate(toDateDraft);
   const commitFromTime   = () => setFromTime(fromTimeDraft);
   const commitToTime     = () => setToTime(toTimeDraft);
 
@@ -111,13 +107,11 @@ const EventsTable = () => {
         fromTime={debouncedFromTime}
         toDate={debouncedToDate}
         toTime={debouncedToTime}
-        onFromDateChange={setFromDateDraft}
+        onFromDateChange={setFromDate}
         onFromTimeChange={setFromTimeDraft}
-        onToDateChange={setToDateDraft}
+        onToDateChange={setToDate}
         onToTimeChange={setToTimeDraft}
-        onFromDateBlur={commitFromDate}
         onFromTimeBlur={commitFromTime}
-        onToDateBlur={commitToDate}
         onToTimeBlur={commitToTime}
         messages={events ?? []}
         onFilterChange={handleFilterChange}

--- a/frontend/src/pages/MessagesTable.tsx
+++ b/frontend/src/pages/MessagesTable.tsx
@@ -29,8 +29,6 @@ type MessageInfo = {
 const MessagesTable = () => {
   const location = useLocation();
 
-  const [fromDateDraft, setFromDateDraft] = useState(initialDate(""));
-  const [toDateDraft, setToDateDraft] = useState(initialDate(""));
   const [fromTimeDraft, setFromTimeDraft] = useState(initialTime(""));
   const [toTimeDraft, setToTimeDraft] = useState(initialTime(""));
 
@@ -54,8 +52,6 @@ const MessagesTable = () => {
 
   const { fetchState, callRequest } = useFetch<MessageInfo[]>(url);
 
-  const commitFromDate   = () => setFromDate(fromDateDraft);
-  const commitToDate     = () => setToDate(toDateDraft);
   const commitFromTime   = () => setFromTime(fromTimeDraft);
   const commitToTime     = () => setToTime(toTimeDraft);
 
@@ -117,13 +113,11 @@ const MessagesTable = () => {
         fromTime={debouncedFromTime}
         toDate={debouncedToDate}
         toTime={debouncedToTime}
-        onFromDateChange={setFromDateDraft}
+        onFromDateChange={setFromDate}
         onFromTimeChange={setFromTimeDraft}
-        onToDateChange={setToDateDraft}
+        onToDateChange={setToDate}
         onToTimeChange={setToTimeDraft}
-        onFromDateBlur={commitFromDate}
         onFromTimeBlur={commitFromTime}
-        onToDateBlur={commitToDate}
         onToTimeBlur={commitToTime}
         messages={messages ?? []}
         onFilterChange={handleFilterChange}

--- a/frontend/src/pages/MessagesTableEbms.tsx
+++ b/frontend/src/pages/MessagesTableEbms.tsx
@@ -29,8 +29,6 @@ type MessageInfo = {
 const MessagesTable = () => {
   const location = useLocation();
 
-  const [fromDateDraft, setFromDateDraft] = useState(initialDate(""));
-  const [toDateDraft, setToDateDraft] = useState(initialDate(""));
   const [fromTimeDraft, setFromTimeDraft] = useState(initialTime(""));
   const [toTimeDraft, setToTimeDraft] = useState(initialTime(""));
 
@@ -54,8 +52,6 @@ const MessagesTable = () => {
 
   const { fetchState, callRequest } = useFetch<MessageInfo[]>(url);
 
-  const commitFromDate   = () => setFromDate(fromDateDraft);
-  const commitToDate     = () => setToDate(toDateDraft);
   const commitFromTime   = () => setFromTime(fromTimeDraft);
   const commitToTime     = () => setToTime(toTimeDraft);
 
@@ -117,13 +113,11 @@ const MessagesTable = () => {
         fromTime={debouncedFromTime}
         toDate={debouncedToDate}
         toTime={debouncedToTime}
-        onFromDateChange={setFromDateDraft}
+        onFromDateChange={setFromDate}
         onFromTimeChange={setFromTimeDraft}
-        onToDateChange={setToDateDraft}
+        onToDateChange={setToDate}
         onToTimeChange={setToTimeDraft}
-        onFromDateBlur={commitFromDate}
         onFromTimeBlur={commitFromTime}
-        onToDateBlur={commitToDate}
         onToTimeBlur={commitToTime}
         messages={messages ?? []}
         onFilterChange={handleFilterChange}


### PR DESCRIPTION
Det viste seg at `DatePicker `(i motsetning til `TimePicker`) er selvlagd component fra NAV sin bibliotek  `nav-datovelger` og støtter ikke håndtering av onBlur hendelse. 
Jeg har ikke funnet en enkel måte til å omdefinere denne adferden. Derfor rullet jeg bare tilbake _draft-commit_ logikken for `DatePicker`-e.
Leg til gjerne deres forslag i kommentarer.

Oppgave: https://github.com/navikt/team-emottak-docs/issues/256

PS. Vi trenger en front-end utvikler for slike situasjoner.
